### PR TITLE
updated requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ packaging==16.8
 PyGithub==1.33
 PyJWT==1.4.2
 pyparsing==2.2.0
-requests==2.13.0
+requests==2.20.1
 six==1.10.0


### PR DESCRIPTION
Github warns about the current version of requests https://github.com/pilosa/getting-started/network/alert/requirements.txt/requests/open This PR updates the requests to a safe version.